### PR TITLE
Enable Claude to comment on pull requests

### DIFF
--- a/guides/claude-code-setup.md
+++ b/guides/claude-code-setup.md
@@ -210,6 +210,97 @@ Feature: Payment Integration
 - Status: Parent task 3 (API endpoints) - sub-task 3.2
 ```
 
+## GitHub Integration & PR Comments
+
+Claude Code integrates with the GitHub CLI (`gh`) to post comments and reviews directly to pull requests. This is essential for collaborative development.
+
+### Prerequisites
+
+1. **Install GitHub CLI**:
+   ```bash
+   # macOS
+   brew install gh
+
+   # Linux
+   sudo apt install gh  # Debian/Ubuntu
+   sudo dnf install gh  # Fedora
+
+   # Windows
+   winget install GitHub.cli
+   ```
+
+2. **Authenticate with GitHub**:
+   ```bash
+   gh auth login
+   ```
+
+### Posting PR Comments
+
+Claude Code can automatically add comments to PRs using these commands:
+
+```bash
+# Add a general comment to a PR
+gh pr comment <PR_NUMBER> --body "Your comment here"
+
+# Add a code review with comments
+gh pr review <PR_NUMBER> --comment --body "Review comments here"
+
+# Approve a PR with comments
+gh pr review <PR_NUMBER> --approve --body "LGTM! Approved with notes..."
+
+# Request changes
+gh pr review <PR_NUMBER> --request-changes --body "Please address these issues..."
+```
+
+### PR Review Workflow
+
+When reviewing or creating PRs, Claude Code should:
+
+1. **Analyze the changes**: `gh pr diff <PR_NUMBER>`
+2. **Check PR details**: `gh pr view <PR_NUMBER>`
+3. **Post structured review**: Use the format below
+
+**Standard PR Comment Format:**
+```markdown
+## Code Review Summary
+
+### Overview
+[Brief description of what this PR does]
+
+### Findings
+
+#### Strengths
+- [What was done well]
+
+#### Issues Found
+| Severity | File | Line | Issue | Suggestion |
+|----------|------|------|-------|------------|
+| 🔴 CRITICAL | `file.py` | 45 | Description | Fix suggestion |
+| 🟠 HIGH | `file.py` | 67 | Description | Fix suggestion |
+| 🟡 MEDIUM | `file.py` | 89 | Description | Fix suggestion |
+
+### Recommendation
+[APPROVE / REQUEST CHANGES / COMMENT]
+```
+
+### Configuring Claude Code to Always Comment on PRs
+
+To ensure Claude Code always adds PR comments, add this to your project's `CLAUDE.md`:
+
+```markdown
+## PR Review Requirements
+
+When working on pull requests:
+1. ALWAYS post a review comment using `gh pr review` or `gh pr comment`
+2. Use the standard review format (see ai-framework/guides/claude-code-setup.md)
+3. Include specific file:line references for all issues
+4. Categorize issues by severity (CRITICAL, HIGH, MEDIUM, LOW)
+```
+
+Or add to your global Claude configuration (see "Global Configuration" section below).
+
+---
+
 ## Custom Commands (Slash Commands)
 
 Claude Code supports custom slash commands. Create shortcuts for ai-dev-orchestrator workflows.
@@ -289,6 +380,54 @@ Check for:
 - Performance issues
 - Code quality and standards
 - Missing tests
+```
+
+**File: `.claude/commands/pr-review.md`**
+```markdown
+Review the current PR and post a comment to GitHub.
+
+Steps:
+1. Get PR details: `gh pr view`
+2. Get PR diff: `gh pr diff`
+3. Analyze changes against CONSTITUTION.md
+4. Review across 5 dimensions (quality, bugs, performance, readability, security)
+5. Post review using `gh pr review` with the standard format
+
+Output format for PR comment:
+## Code Review Summary
+
+### Overview
+[Brief description of changes]
+
+### Findings
+
+#### Strengths
+- [What was done well]
+
+#### Issues Found
+| Severity | File | Line | Issue | Suggestion |
+|----------|------|------|-------|------------|
+| [emoji] | `file` | line | desc | fix |
+
+### Recommendation
+[APPROVE / REQUEST CHANGES / COMMENT]
+
+IMPORTANT: You MUST post this review to GitHub using `gh pr review --comment --body "..."` or `gh pr comment --body "..."`
+```
+
+**File: `.claude/commands/pr-comment.md`**
+```markdown
+Add a comment to the current PR summarizing work done.
+
+Steps:
+1. Get current PR: `gh pr view`
+2. Summarize the changes made in this session
+3. Post comment using `gh pr comment --body "..."`
+
+Include:
+- What was implemented/fixed
+- Files changed
+- Any follow-up items or notes for reviewers
 ```
 
 ### Using Custom Commands
@@ -544,9 +683,92 @@ AI: [Fixes issues]
 You: Run tests, commit with message "feat: add password reset feature"
 ```
 
+## Global Configuration (All Projects)
+
+To make Claude Code behave consistently across ALL your projects, use global configuration files.
+
+### Global CLAUDE.md
+
+Create a global instructions file that applies to all projects:
+
+**Location:** `~/.claude/CLAUDE.md`
+
+```markdown
+# Global Claude Code Instructions
+
+## PR Comment Requirements
+
+When working on any pull request:
+1. ALWAYS post a review comment to GitHub using `gh pr review` or `gh pr comment`
+2. Before completing work on a PR branch, summarize changes with `gh pr comment`
+3. When reviewing PRs, use the standard review format with severity levels
+4. Include specific file:line references for all issues found
+
+## Standard PR Review Format
+
+When posting PR reviews, use this format:
+
+## Code Review Summary
+
+### Overview
+[Brief description of what this PR does]
+
+### Findings
+
+#### Strengths
+- [What was done well]
+
+#### Issues Found
+| Severity | File | Line | Issue | Suggestion |
+|----------|------|------|-------|------------|
+| CRITICAL/HIGH/MEDIUM/LOW | `file` | line | description | fix |
+
+### Recommendation
+[APPROVE / REQUEST CHANGES / COMMENT]
+
+## Git Workflow
+
+- Always create descriptive commit messages
+- Post PR comments when completing significant work
+- Use `gh pr view` to check current PR context
+```
+
+### Global Settings
+
+Claude Code also supports global settings in `~/.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)",
+      "Bash(git:*)"
+    ]
+  }
+}
+```
+
+### Verification
+
+To verify your global config is working:
+
+```bash
+# Check if global CLAUDE.md exists
+cat ~/.claude/CLAUDE.md
+
+# Test gh authentication
+gh auth status
+
+# Test PR commands work
+gh pr list
+```
+
+---
+
 ## Additional Resources
 
-- [Claude Code Documentation](https://code.claude.com/docs)
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)
 - [AI-Dev-Orchestrator Main README](../README.md)
 - [Quick Start Guide](../quick-start/README.md)
 - [Anthropic Console](https://console.anthropic.com) (for API keys)

--- a/personas/04-qa-engineer.md
+++ b/personas/04-qa-engineer.md
@@ -54,7 +54,42 @@ The QA Engineer **validates** the implementation. This persona is an expert in q
 - Specific recommendations with file:line references
 - Positive feedback (what was done well)
 
-### 2. Bug List
+### 2. GitHub PR Comments
+**Format:** GitHub-compatible markdown posted via `gh` CLI
+
+**Contents:**
+- Code Review Summary with overview
+- Findings table with severity, file, line, issue, suggestion
+- Strengths identified
+- Recommendation (APPROVE / REQUEST CHANGES / COMMENT)
+
+**How to Post:**
+```bash
+# Post a review comment
+gh pr review <PR_NUMBER> --comment --body "$(cat <<'EOF'
+## Code Review Summary
+
+### Overview
+[Description of PR changes]
+
+### Findings
+| Severity | File | Line | Issue | Suggestion |
+|----------|------|------|-------|------------|
+| 🔴 CRITICAL | `file.py` | 45 | Issue description | Fix suggestion |
+
+### Recommendation
+COMMENT - Please address the issues above.
+EOF
+)"
+
+# Or approve with comments
+gh pr review <PR_NUMBER> --approve --body "LGTM! Great work on..."
+
+# Or request changes
+gh pr review <PR_NUMBER> --request-changes --body "Please fix..."
+```
+
+### 3. Bug List
 **Format:** Checklist or table
 
 **Contents:**
@@ -64,7 +99,7 @@ The QA Engineer **validates** the implementation. This persona is an expert in q
 - Reproduction steps (if applicable)
 - Suggested fix
 
-### 3. Edge Case Analysis
+### 4. Edge Case Analysis
 **Format:** List or table
 
 **Contents:**
@@ -72,7 +107,7 @@ The QA Engineer **validates** the implementation. This persona is an expert in q
 - Expected behavior for each
 - Current handling (pass/fail)
 
-### 4. Security Audit Report
+### 5. Security Audit Report
 **Format:** Structured markdown
 
 **Contents:**
@@ -93,6 +128,69 @@ This persona uses the following prompt templates (located in `/prompts/`):
 - **[Phase 3: Security Audit](../prompts/phase-3-review/3.3-qa-security-audit.md)** - Security-focused review
 - **[Phase 3: Style & Standards](../prompts/phase-3-review/3.4-qa-style-standards.md)** - Linting and standards check
 - **[Phase 3: Testability](../prompts/phase-3-review/3.5-qa-testability.md)** - Assessment for unit testing
+
+## GitHub PR Review Workflow
+
+When reviewing pull requests, the QA Engineer should **always post comments to GitHub**:
+
+### Step 1: Gather Context
+```bash
+# View PR details
+gh pr view <PR_NUMBER>
+
+# Get the diff
+gh pr diff <PR_NUMBER>
+
+# Check PR files changed
+gh pr view <PR_NUMBER> --json files
+```
+
+### Step 2: Perform Review
+- Apply the 5 Dimensions of Code Quality (see below)
+- Reference CONSTITUTION.md for project standards
+- Note specific file:line locations for all issues
+
+### Step 3: Post Review to GitHub
+```bash
+# For general feedback
+gh pr review <PR_NUMBER> --comment --body "Review content..."
+
+# To approve
+gh pr review <PR_NUMBER> --approve --body "LGTM! ..."
+
+# To request changes
+gh pr review <PR_NUMBER> --request-changes --body "Please fix..."
+```
+
+### PR Comment Best Practices
+
+**ALWAYS include:**
+- Overview of what the PR does
+- Specific file:line references
+- Severity levels (CRITICAL, HIGH, MEDIUM, LOW)
+- Clear recommendation (APPROVE/REQUEST CHANGES/COMMENT)
+
+**Use this format:**
+```markdown
+## Code Review Summary
+
+### Overview
+Brief description of the changes reviewed.
+
+### Findings
+
+#### Strengths
+- What was done well
+
+#### Issues Found
+| Severity | File | Line | Issue | Suggestion |
+|----------|------|------|-------|------------|
+| 🔴 CRITICAL | `file.py` | 45 | Description | Fix |
+| 🟠 HIGH | `file.py` | 67 | Description | Fix |
+
+### Recommendation
+[APPROVE / REQUEST CHANGES / COMMENT]
+```
 
 ## The 5 Dimensions of Code Quality
 


### PR DESCRIPTION
- Add GitHub Integration & PR Comments section to claude-code-setup.md
  - Prerequisites for gh CLI installation
  - PR comment commands and workflows
  - Standard PR review format template
  - Custom slash commands for /pr-review and /pr-comment
  - Global Configuration section for ~/.claude/CLAUDE.md

- Update QA Engineer persona with PR commenting capabilities
  - Add GitHub PR Comments as key artifact
  - Add GitHub PR Review Workflow section
  - Include step-by-step PR review process
  - Add PR comment best practices and format template
  
(Essentially - adapting the process so that when clicking the PR button Claude Code Web automatically provides comments on the PR - have also updated my local claude code global prefs)